### PR TITLE
Added table identifiers

### DIFF
--- a/examples/chess/metadata.json
+++ b/examples/chess/metadata.json
@@ -1,6 +1,7 @@
 {
   "tables": [
     {
+      "id": "game",
       "name": "game",
       "primary_key": "game_id",
       "fields": [
@@ -139,6 +140,7 @@
       ]
     },
     {
+      "id": "opening",
       "name": "opening",
       "primary_key": "opening_id",
       "fields": [

--- a/examples/hello_world/metadata.json
+++ b/examples/hello_world/metadata.json
@@ -2,6 +2,7 @@
     "path": "/path/to/dataset",
     "tables": [
         {
+            "id": "68d22534-a598-11ea-8ab6-149d997bb0cb",
             "name": "users",
             "fields": [
                 {"name": "user_id"},
@@ -11,6 +12,7 @@
             ]
         },
         {
+            "id": "7006f500-a598-11ea-8ab6-149d997bb0cb",
             "name": "transactions",
             "fields": [
                 {"name": "tx_id"},
@@ -23,15 +25,15 @@
     ],
     "foreign_keys": [
         {
-            "table": "transactions",
+            "table": "7006f500-a598-11ea-8ab6-149d997bb0cb",
             "field": "tx_uid",
-            "ref_table": "users",
+            "ref_table": "68d22534-a598-11ea-8ab6-149d997bb0cb",
             "ref_field": "user_id"
         },
         {
-            "table": "transactions",
+            "table": "7006f500-a598-11ea-8ab6-149d997bb0cb",
             "field": ["sender_first", "sender_last"],
-            "ref_table": "users",
+            "ref_table": "68d22534-a598-11ea-8ab6-149d997bb0cb",
             "ref_field": ["firstname", "lastname"]
         }
     ],
@@ -39,10 +41,10 @@
         {
             "constraint_type": "validity",
             "fields_under_consideration": [
-                {"table": "users", "field": "total"}
+                {"table": "68d22534-a598-11ea-8ab6-149d997bb0cb", "field": "total"}
             ],
             "related_fields": [
-                {"table": "transactions", "field": "amount"}
+                {"table": "7006f500-a598-11ea-8ab6-149d997bb0cb", "field": "amount"}
             ]
         }
     ]

--- a/examples/nba/metadata.json
+++ b/examples/nba/metadata.json
@@ -8,152 +8,184 @@
       ],
       "fields": [
         {
-          "name": "GameId",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "GameId"
         },
         {
-          "name": "TeamId",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "TeamId"
         },
         {
-          "name": "PlayerId",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "PlayerId"
         },
         {
-          "name": "Minutes",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "Minutes"
         },
         {
-          "name": "FieldGoalsMade",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "FieldGoalsMade"
         },
         {
-          "name": "FieldGoalAttempts",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "FieldGoalAttempts"
         },
         {
-          "name": "3PointsMade",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "3PointsMade"
         },
         {
-          "name": "3PointAttempts",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "3PointAttempts"
         },
         {
-          "name": "FreeThrowsMade",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "FreeThrowsMade"
         },
         {
-          "name": "FreeThrowAttempts",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "FreeThrowAttempts"
         },
         {
-          "name": "PlusMinus",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "PlusMinus"
         },
         {
-          "name": "OffensiveRebounds",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "OffensiveRebounds"
         },
         {
-          "name": "DefensiveRebounds",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "DefensiveRebounds"
         },
         {
-          "name": "TotalRebounds",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "TotalRebounds"
         },
         {
-          "name": "Assists",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "Assists"
         },
         {
-          "name": "PersonalFouls",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "PersonalFouls"
         },
         {
-          "name": "Steals",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "Steals"
         },
         {
-          "name": "Turnovers",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "Turnovers"
         },
         {
-          "name": "BlockedShots",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "BlockedShots"
         },
         {
-          "name": "BlocksAgainst",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "BlocksAgainst"
         },
         {
-          "name": "Points",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "Points"
         },
         {
-          "name": "Starter",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "Starter"
         }
-      ]
+      ],
+      "id": "Actions"
     },
     {
       "name": "Game",
       "primary_key": "GameId",
       "fields": [
         {
-          "name": "GameId",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "GameId"
         },
         {
-          "name": "Team1Id",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "Team1Id"
         },
         {
-          "name": "Team2Id",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "Team2Id"
         },
         {
-          "name": "ResultOfTeam1",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "ResultOfTeam1"
         },
         {
-          "name": "URL",
-          "data_type": "text"
+          "data_type": "categorical",
+          "name": "URL"
         },
         {
-          "name": "Date",
-          "data_type": "datetime"
+          "data_type": "datetime",
+          "name": "Date"
         }
-      ]
+      ],
+      "id": "Game"
     },
     {
       "name": "Player",
       "primary_key": "PlayerId",
       "fields": [
         {
-          "name": "PlayerId",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "PlayerId"
         },
         {
-          "name": "PlayerName",
-          "data_type": "text"
+          "data_type": "categorical",
+          "name": "PlayerName"
         }
-      ]
+      ],
+      "id": "Player"
     },
     {
       "name": "Team",
       "primary_key": "TeamId",
       "fields": [
         {
-          "name": "TeamId",
-          "data_type": "numerical"
+          "data_type": "numerical",
+          "data_subtype": "integer",
+          "name": "TeamId"
         },
         {
-          "name": "TeamName",
-          "data_type": "text"
+          "data_type": "categorical",
+          "name": "TeamName"
         }
-      ]
+      ],
+      "id": "Team"
     }
   ],
   "foreign_keys": [

--- a/examples/pyrimidine/metadata.json
+++ b/examples/pyrimidine/metadata.json
@@ -1,6 +1,7 @@
 {
   "tables": [
     {
+      "id": "molecule",
       "name": "molecule",
       "primary_key": "molecule_id",
       "fields": [
@@ -15,6 +16,7 @@
       ]
     },
     {
+      "id": "position",
       "name": "position",
       "primary_key": [
         "molecule_id",

--- a/metad/connectors/dataframe.py
+++ b/metad/connectors/dataframe.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import uuid
 
 from metad.connectors.base import BaseConnector
 
@@ -58,6 +59,7 @@ class DataFrameConnector(BaseConnector):
         table_metadata = []
         for table_name, dataframe in self.tables.items():
             table_metadata.append({
+                "id": str(uuid.uuid1()),
                 "name": table_name,
                 "fields": self._analyze_fields(dataframe)
             })

--- a/metad/connectors/mysql.py
+++ b/metad/connectors/mysql.py
@@ -69,7 +69,9 @@ class MySQLConnector(BaseConnector):
     def _tables(self, cursor):
         tables = []
         for table_name in self._table_names(cursor):
-            tables.append(self._table_metadata(cursor, table_name))
+            table_metadata = self._table_metadata(cursor, table_name)
+            table_metadata["id"] = table_name  # table names are unique
+            tables.append(table_metadata)
         return tables
 
     def _foreign_keys(self, cursor):

--- a/metad/metadata.py
+++ b/metad/metadata.py
@@ -89,12 +89,12 @@ class MetaData():
         validate(self.data)
 
         # Assert that field names are unique
-        table_names, field_names = [], []
+        table_ids, field_names = [], []
         for table in self.data["tables"]:
-            table_names.append(table["name"])
+            table_ids.append(table["id"])
             for field in table["fields"]:
-                field_names.append((table["name"], field["name"]))
-        assert len(table_names) == len(set(table_names))
+                field_names.append((table["id"], field["name"]))
+        assert len(table_ids) == len(set(table_ids))
         assert len(field_names) == len(set(field_names))
 
         # Assert that the foreign key fields exist

--- a/metad/schema.json
+++ b/metad/schema.json
@@ -17,6 +17,10 @@
             "items": {
                 "type": "object",
                 "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The unique id for the table."
+                    },
                     "path": {
                         "type": "string",
                         "description": "The path to the CSV file."
@@ -97,7 +101,7 @@
                         "description": "This is the application the table came from."
                     }
                 },
-                "required": ["name", "fields"]
+                "required": ["id", "fields"]
             }
         },
         "foreign_keys": {
@@ -108,7 +112,7 @@
                 "properties": {
                     "table": {
                         "type": "string",
-                        "description": "The name of the child table."
+                        "description": "The id of the child table."
                     },
                     "field": {
                         "anyOf": [
@@ -127,7 +131,7 @@
                     },
                     "ref_table": {
                         "type": "string",
-                        "description": "The name of the child table."
+                        "description": "The id of the child table."
                     },
                     "ref_field": {
                         "anyOf": [
@@ -165,7 +169,7 @@
                             "properties": {
                                 "table": {
                                     "type": "string",
-                                    "description": "The table to which the field belongs."
+                                    "description": "The id of the table to which the field belongs."
                                 }, 
                                 "field": {
                                     "type": "string",
@@ -181,7 +185,7 @@
                             "properties": {
                                 "table": {
                                     "type": "string",
-                                    "description": "The table to which the field belongs."
+                                    "description": "The id of the table to which the field belongs."
                                 }, 
                                 "field": {
                                     "type": "string",

--- a/tests/test_metad.py
+++ b/tests/test_metad.py
@@ -19,6 +19,7 @@ class TestMetaData(TestCase):
     def test_creation(self):
         metadata = MetaData()
         metadata.add_table({
+            "id": "users",
             "name": "users",
             "fields": [
                 {"name": "user_id", "data_type": "id"},


### PR DESCRIPTION
Addresses #13. In essence, this adds an "id" field to the table object which replaces the functionality old "name" field. However, the old "name" field is still allowed/supported, it's just no longer being referenced by foreign key and constraint objects.

I still think we should evaluate the necessity and user friendliness of the id field but this should implement the functionality discussed in #13.